### PR TITLE
4 | Prefer aria selector over xpath when both are available

### DIFF
--- a/src/stringifyExtension.ts
+++ b/src/stringifyExtension.ts
@@ -270,16 +270,7 @@ export class StringifyExtension extends PuppeteerStringifyExtension {
         if (idSelector) return idSelector
 
         /**
-         * use xPath selector if available
-         */
-        const xPathSelector = findByCondition(
-            selectors,
-            (s) => s.startsWith(XPATH_PREFIX)
-        )
-        if (xPathSelector) return `"${xPathSelector.slice(XPATH_PREFIX.length + 1)}`
-
-        /**
-         * use WebdriverIOs aria selector
+         * Use WebdriverIOs aria selector as second option
          * https://webdriver.io/docs/selectors#accessibility-name-selector
          */
         const ariaSelector = findByCondition(
@@ -290,6 +281,15 @@ export class StringifyExtension extends PuppeteerStringifyExtension {
 
         // Remove Aria selectors
         const nonAriaSelectors = this.filterArrayByString(selectors, ARIA_PREFIX)
+
+        /**
+         * use xPath selector if aria selector is not available
+         */
+        const xPathSelector = findByCondition(
+            selectors,
+            (s) => s.startsWith(XPATH_PREFIX)
+        )
+        if (xPathSelector) return `"${xPathSelector.slice(XPATH_PREFIX.length + 1)}`
 
         let preferredSelector
 

--- a/test/stringifyExtension.test.ts
+++ b/test/stringifyExtension.test.ts
@@ -87,7 +87,7 @@ describe('StringifyExtension', () => {
         expect(writer.toString()).toBe('await browser.$("#heading").setValue("webdriverio")\n')
     })
 
-    it('should prefer xPath selector', async () => {
+    it('should prefer aria selector over xpath', async () => {
         const ext = new StringifyExtension()
         const step = {
             type: StepType.Change as const,
@@ -98,7 +98,7 @@ describe('StringifyExtension', () => {
         const flow = { title: 'change step', steps: [step] }
         const writer = new InMemoryLineWriter('  ')
         await ext.stringifyStep(writer, step, flow)
-        expect(writer.toString()).toBe('await browser.$("//*[@data-test=\\"heading\\"]").setValue("webdriverio")\n')
+        expect(writer.toString()).toBe('await browser.$("aria/Search").setValue("webdriverio")\n')
     })
 
     it('should prefer link text selectors', async () => {


### PR DESCRIPTION
Currently, the code for converting JSON user flows into WebdriverIO test scripts prioritizes XPath selectors over ARIA selectors. However, it would be more desirable to have ARIA selectors as the preferred choice.

fixes #4

**Changes Made:**
- Modified the getSelector() method in stringifyExtension.ts to prioritize ARIA selectors over XPath selectors.
- Updated the order of selector checks to first look for ARIA selectors and return them if available, and only then check for XPath selectors.
- Updated unit tests to reflect the changes